### PR TITLE
NullTerminatedArrayIterator fix (probably)

### DIFF
--- a/fish-rust/src/null_terminated_array.rs
+++ b/fish-rust/src/null_terminated_array.rs
@@ -33,12 +33,13 @@ pub struct NullTerminatedArrayIterator<CharType> {
 impl<CharType> Iterator for NullTerminatedArrayIterator<CharType> {
     type Item = *const CharType;
     fn next(&mut self) -> Option<*const CharType> {
-        if self.ptr.is_null() {
-            return None;
-        }
         let result = unsafe { *self.ptr };
-        self.ptr = unsafe { self.ptr.add(1) };
-        Some(result)
+        if result.is_null() {
+            None
+        } else {
+            self.ptr = unsafe { self.ptr.add(1) };
+            Some(result)
+        }
     }
 }
 
@@ -148,6 +149,15 @@ fn test_null_terminated_array() {
         assert_eq!(CStr::from_ptr(*ptr.offset(1)).to_str().unwrap(), "bar");
         assert_eq!(*ptr.offset(2), ptr::null());
     }
+}
+#[test]
+fn test_null_terminated_array_iter() {
+    let owned_strs = &[CString::new("foo").unwrap(), CString::new("bar").unwrap()];
+    let strs: Vec<_> = owned_strs.iter().map(|s| s.as_c_str()).collect();
+    let arr = NullTerminatedArray::new(&strs);
+    let v1: Vec<_> = arr.iter().collect();
+    let v2: Vec<_> = owned_strs.iter().map(|s| s.as_ptr()).collect();
+    assert_eq!(v1, v2);
 }
 
 #[test]


### PR DESCRIPTION
Hi! For some reason I cannot see a comment I left under [your pull request in the upstream fish repo](https://github.com/fish-shell/fish-shell/pull/9726), so I decided I should turn it into a pr instead. Here's the original comment:

Pretty sure this code is bugged.

It's essentially equivalent to C++'s
```cpp
template<typename CharType>
struct NullTerminatedArrayIterator {
    CharType const* * ptr;
    
    auto next() -> Option<CharType const*> {
        if ptr == nullptr {
            return None();
        }
        auto result = *ptr;
        ptr++;
        return Some(result)
    }
}
```
As you can see, `ptr` incrementing isn't bounded and won't turn it `nullptr`, so this code eventually SIGSEGVs. Example test:
```rust
#[test]
fn test_null_terminated_array_iter() {
    let owned_strs = &[CString::new("foo").unwrap(), CString::new("bar").unwrap()];
    let strs: Vec<_> = owned_strs.iter().map(|s| s.as_c_str()).collect();
    let arr = NullTerminatedArray::new(&strs);
    let v1: Vec<_> = arr.iter().collect(); // SIGSEGVs here
    let v2: Vec<_> = owned_strs.iter().map(|s| s.as_ptr()).collect();
    assert_eq!(v1, v2);
}
```

I guess the intention was
```rust
pub struct NullTerminatedArrayIterator<CharType> {
    ptr: *mut *const CharType,
}
impl<CharType> Iterator for NullTerminatedArrayIterator<CharType> {
    type Item = *const CharType;
    fn next(&mut self) -> Option<*const CharType> {
        let result = unsafe { *self.ptr };
        if result.is_null() {
            None
        } else {
            self.ptr = unsafe { self.ptr.add(1) };
            Some(result)
        }
    }
}
```
AKA

```cpp
template<typename CharType>
struct NullTerminatedArrayIterator {
    CharType const* * ptr;
    
    auto next() -> Option<CharType const*> {
        auto result = *ptr;
        if (result == nullptr) {
            return None();
        } else {
            ptr++;
            return Some(result);
        }
    }
}
```
but I might be wrong.
